### PR TITLE
Fix inifinite logging and rate limiting typo

### DIFF
--- a/mkchal/templates/docker-compose.yml
+++ b/mkchal/templates/docker-compose.yml
@@ -7,6 +7,8 @@ services:
             context: ../
         logging:
             driver: "json-file"
+            max-size: "50k"
+            max-file: "3"
         expose: # This should be the port your challenge runs on inside the container.
             - "{port}"
         labels: # If you have a second service make sure the service name and port are replaced

--- a/mkchal/templates/pwn/docker-compose.yml
+++ b/mkchal/templates/pwn/docker-compose.yml
@@ -8,6 +8,8 @@ services:
             context: ../
         logging:
             driver: "json-file"
+            max-size: "50k"
+            max-file: "3"
         restart: always
         expose: # This should be the port your challenge runs on inside the container.
             - "{port}"

--- a/mkchal/templates/web/docker-compose.yml
+++ b/mkchal/templates/web/docker-compose.yml
@@ -17,8 +17,8 @@ services:
             - "traefik.http.routers.${{COMPOSE_PROJECT_NAME}}.tls={{}}"
             - "traefik.http.routers.${{COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
             # Delete this line, edit and uncomment the lines below to configure rate limiting for your service
-            # - "traefik.http.middlewares.fluf.ratelimit.average=100"
-            # - "traefik.http.routers.${{COMPOSE_PROJECT_NAME}}.middlewares=fluf"  
-            # - "traefik.http.middlewares.fluf.ratelimit.burst=100"
+            # - "traefik.http.middlewares.ffuf-${{COMPOSE_PROJECT_NAME}}.ratelimit.average=100"
+            # - "traefik.http.routers.${{COMPOSE_PROJECT_NAME}}.middlewares=ffuf-${{COMPOSE_PROJECT_NAME}}"  
+            # - "traefik.http.middlewares.ffuf-${{COMPOSE_PROJECT_NAME}}.ratelimit.burst=100"
         ports:
             - "1337:{port}"

--- a/mkchal/templates/web/docker-compose.yml
+++ b/mkchal/templates/web/docker-compose.yml
@@ -7,6 +7,8 @@ services:
             context: ../
         logging:
             driver: "json-file"
+            max-size: "50k"
+            max-file: "3"
         expose: # This should be the port your challenge runs on inside the container.
             - "{port}"
         labels: # please do not delete these labels, if you have a second service make sure the service name and port are replaced


### PR DESCRIPTION
Checklist For PRs:

- [ ] Ports have been commented out in your `docker-compose.yml` if applicable.
 ```yml
 ports:
  - 1337
 ```
 becomes
 ```yml
 # ports:
 # - 1337
 ```
- [ ] Traefik network has been uncommented in your `docker-compose.yml` if applicable.
 ```yml
     # external: true  
 ```
 becomes
 ```yml
    external: true 
 ``` 
- [ ] Is solvable (you don't have to solve it blind, just go through the solve and validate it and sanity check it)
- [ ] Flag is in `bctf{...}` format (if impossible, the format is noted in the description.)
- [ ] Writeup is present in `solve/README.md`
- [ ] Writeup is high quality and completely explains how to solve the challenge from scratch
- [ ] `chal.json` is present in the challenge root directory and contains:
  - [ ] Challenge Title
  - [ ] Challenge Author
  - [ ] Challenge Difficulty `[Easy, Medium, Hard]`
  - [ ] Challenge Description (for distribution, this is your flavor text)
- [ ] Local build files are present in `./src` if applicable (Makefile etc)
- [ ] Remote deployment files are present in `./deploy` if applicable.
  - [ ] Dockerfile
  - [ ] docker-compose.yml
  - [ ] run.sh
  - [ ] challenge.yml